### PR TITLE
More detailed test of sklearn.linear_model

### DIFF
--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -65,6 +65,8 @@ sklearn.linear_model.tests.test_theil_sen.py
 
 expected_test_results = {tf: ["passed"] for tf in test_files}
 
+test_submodules = expected_test_results.keys()
+
 async def _read_stream(stream, cb, timeout_without_output):
     while True:
         loop = asyncio.get_event_loop_policy().get_event_loop()

--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -6,43 +6,64 @@ import asyncio
 # Test submodules are from the output of the command run from the scikit-learn
 # root folder:
 # find sklearn -name tests | sort | perl -pe 's@/@.@g'
-expected_test_results = {
-    "sklearn.cluster.tests": ["passed"],
-    "sklearn.compose.tests": ["passed"],
-    "sklearn.covariance.tests": ["passed"],
-    "sklearn.cross_decomposition.tests": ["passed"],
-    "sklearn.datasets.tests": ["passed"],
-    "sklearn.decomposition.tests": ["passed"],
-    "sklearn.ensemble._hist_gradient_boosting.tests": ["passed"],
-    "sklearn.ensemble.tests": ["fatal error or timeout", "failed"],
-    "sklearn.experimental.tests": ["failed"],
-    "sklearn.feature_extraction.tests": ["failed"],
-    "sklearn.feature_selection.tests": ["fatal error or timeout", "failed", "passed"],
-    "sklearn.gaussian_process.tests": ["passed"],
-    "sklearn.impute.tests": ["passed"],
-    "sklearn.inspection._plot.tests": ["passed"],
-    "sklearn.inspection.tests": ["fatal error or timeout"],
-    "sklearn.linear_model._glm.tests": ["passed"],
-    "sklearn.linear_model.tests": ["fatal error or timeout"],
-    "sklearn._loss.tests": ["failed"],
-    "sklearn.manifold.tests": ["passed"],
-    "sklearn.metrics.cluster.tests": ["passed"],
-    "sklearn.metrics._plot.tests": ["passed"],
-    "sklearn.metrics.tests": ["passed"],
-    "sklearn.mixture.tests": ["passed"],
-    "sklearn.model_selection.tests": ["passed"],
-    "sklearn.neighbors.tests": ["passed"],
-    "sklearn.neural_network.tests": ["passed"],
-    "sklearn.preprocessing.tests": ["passed"],
-    "sklearn.semi_supervised.tests": ["passed"],
-    "sklearn.svm.tests": ["failed"],
-    "sklearn.tests": ["failed", "fatal error or timeout"],
-    "sklearn.tree.tests": ["failed"],
-    "sklearn.utils.tests": ["failed"],
-}
+# expected_test_results = {
+#     "sklearn.cluster.tests": ["passed"],
+#     "sklearn.compose.tests": ["passed"],
+#     "sklearn.covariance.tests": ["passed"],
+#     "sklearn.cross_decomposition.tests": ["passed"],
+#     "sklearn.datasets.tests": ["passed"],
+#     "sklearn.decomposition.tests": ["passed"],
+#     "sklearn.ensemble._hist_gradient_boosting.tests": ["passed"],
+#     "sklearn.ensemble.tests": ["fatal error or timeout", "failed"],
+#     "sklearn.experimental.tests": ["failed"],
+#     "sklearn.feature_extraction.tests": ["failed"],
+#     "sklearn.feature_selection.tests": ["fatal error or timeout", "failed", "passed"],
+#     "sklearn.gaussian_process.tests": ["passed"],
+#     "sklearn.impute.tests": ["passed"],
+#     "sklearn.inspection._plot.tests": ["passed"],
+#     "sklearn.inspection.tests": ["fatal error or timeout"],
+#     "sklearn.linear_model._glm.tests": ["passed"],
+#     "sklearn.linear_model.tests": ["fatal error or timeout"],
+#     "sklearn._loss.tests": ["failed"],
+#     "sklearn.manifold.tests": ["passed"],
+#     "sklearn.metrics.cluster.tests": ["passed"],
+#     "sklearn.metrics._plot.tests": ["passed"],
+#     "sklearn.metrics.tests": ["passed"],
+#     "sklearn.mixture.tests": ["passed"],
+#     "sklearn.model_selection.tests": ["passed"],
+#     "sklearn.neighbors.tests": ["passed"],
+#     "sklearn.neural_network.tests": ["passed"],
+#     "sklearn.preprocessing.tests": ["passed"],
+#     "sklearn.semi_supervised.tests": ["passed"],
+#     "sklearn.svm.tests": ["failed"],
+#     "sklearn.tests": ["failed", "fatal error or timeout"],
+#     "sklearn.tree.tests": ["failed"],
+#     "sklearn.utils.tests": ["failed"],
+# }
 
-test_submodules = expected_test_results.keys()
+test_files = """
+sklearn.linear_model._glm.tests.test_glm.py
+sklearn.linear_model.tests.test_base.py
+sklearn.linear_model.tests.test_bayes.py
+sklearn.linear_model.tests.test_common.py
+sklearn.linear_model.tests.test_coordinate_descent.py
+sklearn.linear_model.tests.test_huber.py
+sklearn.linear_model.tests.test_least_angle.py
+sklearn.linear_model.tests.test_linear_loss.py
+sklearn.linear_model.tests.test_logistic.py
+sklearn.linear_model.tests.test_omp.py
+sklearn.linear_model.tests.test_passive_aggressive.py
+sklearn.linear_model.tests.test_perceptron.py
+sklearn.linear_model.tests.test_quantile.py
+sklearn.linear_model.tests.test_ransac.py
+sklearn.linear_model.tests.test_ridge.py
+sklearn.linear_model.tests.test_sag.py
+sklearn.linear_model.tests.test_sgd.py
+sklearn.linear_model.tests.test_sparse_coordinate_descent.py
+sklearn.linear_model.tests.test_theil_sen.py
+""".split()
 
+expected_test_results = {tf: ["passed"] for tf in test_files}
 
 async def _read_stream(stream, cb, timeout_without_output):
     while True:

--- a/run-tests-by-module.py
+++ b/run-tests-by-module.py
@@ -42,25 +42,25 @@ import asyncio
 # }
 
 test_files = """
-sklearn.linear_model._glm.tests.test_glm.py
-sklearn.linear_model.tests.test_base.py
-sklearn.linear_model.tests.test_bayes.py
-sklearn.linear_model.tests.test_common.py
-sklearn.linear_model.tests.test_coordinate_descent.py
-sklearn.linear_model.tests.test_huber.py
-sklearn.linear_model.tests.test_least_angle.py
-sklearn.linear_model.tests.test_linear_loss.py
-sklearn.linear_model.tests.test_logistic.py
-sklearn.linear_model.tests.test_omp.py
-sklearn.linear_model.tests.test_passive_aggressive.py
-sklearn.linear_model.tests.test_perceptron.py
-sklearn.linear_model.tests.test_quantile.py
-sklearn.linear_model.tests.test_ransac.py
-sklearn.linear_model.tests.test_ridge.py
-sklearn.linear_model.tests.test_sag.py
-sklearn.linear_model.tests.test_sgd.py
-sklearn.linear_model.tests.test_sparse_coordinate_descent.py
-sklearn.linear_model.tests.test_theil_sen.py
+sklearn.linear_model._glm.tests.test_glm
+sklearn.linear_model.tests.test_base
+sklearn.linear_model.tests.test_bayes
+sklearn.linear_model.tests.test_common
+sklearn.linear_model.tests.test_coordinate_descent
+sklearn.linear_model.tests.test_huber
+sklearn.linear_model.tests.test_least_angle
+sklearn.linear_model.tests.test_linear_loss
+sklearn.linear_model.tests.test_logistic
+sklearn.linear_model.tests.test_omp
+sklearn.linear_model.tests.test_passive_aggressive
+sklearn.linear_model.tests.test_perceptron
+sklearn.linear_model.tests.test_quantile
+sklearn.linear_model.tests.test_ransac
+sklearn.linear_model.tests.test_ridge
+sklearn.linear_model.tests.test_sag
+sklearn.linear_model.tests.test_sgd
+sklearn.linear_model.tests.test_sparse_coordinate_descent
+sklearn.linear_model.tests.test_theil_sen
 """.split()
 
 expected_test_results = {tf: ["passed"] for tf in test_files}


### PR DESCRIPTION
# sklearn.linear_model.tests.test_base

sometimes pass sometimes not.

This seems to pass consistently:
```
node --experimental-fetch scikit-learn-pytest.js --pyargs sklearn.linear_model.tests.test_base -v -k 'not regression_multiple_outcome'
```

This sometimes passes, sometimes hangs, sometimes errors with an error that does not make sense, sometimes with a Pyodide stack-trace
```
node --experimental-fetch scikit-learn-pytest.js --pyargs sklearn.linear_model.tests.test_base -v -k 'regression_multiple_outcome'
```

Example of stack-trace:
```
The cause of the fatal error was:
RuntimeError: null function or function signature mismatch
    at method_vectorcall (wasm://wasm/0200c0f2:wasm-function[1053]:0x1334a6)
    at call_function (wasm://wasm/0200c0f2:wasm-function[3087]:0x1ed8e7)
    at _PyEval_EvalFrameDefault (wasm://wasm/0200c0f2:wasm-function[3078]:0x1eb5c1)
    at _PyEval_Vector (wasm://wasm/0200c0f2:wasm-function[3075]:0x1e5b15)
    at _PyFunction_Vectorcall (wasm://wasm/0200c0f2:wasm-function[1010]:0x131b47)
    at call_function (wasm://wasm/0200c0f2:wasm-function[3087]:0x1ed8e7)
    at _PyEval_EvalFrameDefault (wasm://wasm/0200c0f2:wasm-function[3078]:0x1eb5c1)
    at _PyEval_Vector (wasm://wasm/0200c0f2:wasm-function[3075]:0x1e5b15)
    at _PyFunction_Vectorcall (wasm://wasm/0200c0f2:wasm-function[1010]:0x131b47)
    at PyVectorcall_Call (wasm://wasm/0200c0f2:wasm-function[1007]:0x1319a4) {
  pyodide_fatal_error: true
}
RuntimeError: null function or function signature mismatch
    at method_vectorcall (wasm://wasm/0200c0f2:wasm-function[1053]:0x1334a6)
    at call_function (wasm://wasm/0200c0f2:wasm-function[3087]:0x1ed8e7)
    at _PyEval_EvalFrameDefault (wasm://wasm/0200c0f2:wasm-function[3078]:0x1eb5c1)
    at _PyEval_Vector (wasm://wasm/0200c0f2:wasm-function[3075]:0x1e5b15)
    at _PyFunction_Vectorcall (wasm://wasm/0200c0f2:wasm-function[1010]:0x131b47)
    at call_function (wasm://wasm/0200c0f2:wasm-function[3087]:0x1ed8e7)
    at _PyEval_EvalFrameDefault (wasm://wasm/0200c0f2:wasm-function[3078]:0x1eb5c1)
    at _PyEval_Vector (wasm://wasm/0200c0f2:wasm-function[3075]:0x1e5b15)
    at _PyFunction_Vectorcall (wasm://wasm/0200c0f2:wasm-function[1010]:0x131b47)
    at PyVectorcall_Call (wasm://wasm/0200c0f2:wasm-function[1007]:0x1319a4) {
  pyodide_fatal_error: true
}
```

# sklearn.linear_model.tests.test_ransac

Sometimes pass sometimes not.

This seems to consistently pass:
```
node --experimental-fetch scikit-learn-pytest.js --pyargs sklearn.linear_model.tests.test_ransac -v -k 'not test_ransac_final_model_fit_sample_weight'
```

```
node --experimental-fetch scikit-learn-pytest.js --pyargs sklearn.linear_model.tests.test_ransac -v -k 'test_ransac_final_model_fit_sample_weight'
```


Example of a Python error that does not make sense:
```
=================================== FAILURES ===================================
__________________ test_ransac_final_model_fit_sample_weight ___________________

>   ???

/lib/python3.10/site-packages/sklearn/linear_model/tests/test_ransac.py:550: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/lib/python3.10/site-packages/sklearn/linear_model/_ransac.py:553: in fit
    ???
/lib/python3.10/site-packages/sklearn/linear_model/_base.py:700: in fit
    ???
/lib/python3.10/site-packages/scipy/linalg/_basic.py:1134: in lstsq
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = array([[ 0.00366151,  0.00924783,  0.00666857, ..., -0.02802901,
        -0.02554151,  0.02791069],
       [-0.0130917...516, -0.02085857],
       [-0.01815295, -0.01296848, -0.03640656, ..., -0.00140703,
        -0.00273846, -0.01851021]])
check_finite = True, sparse_ok = False, objects_ok = False, mask_ok = False
as_inexact = False

>   ???
E   SystemError: Objects/dictobject.c:1514: bad argument to internal function

/lib/python3.10/site-packages/scipy/_lib/_util.py:278: SystemError
=========================== short test summary info ============================
FAILED ::test_ransac_final_model_fit_sample_weight - SystemError: Objects/dictobject.c:1514: bad argument to internal function
======================= 1 failed, 24 deselected in 3.58s =======================
```